### PR TITLE
add extra IPMI calls.

### DIFF
--- a/pyghmi/ipmi/command.py
+++ b/pyghmi/ipmi/command.py
@@ -378,3 +378,427 @@ class Command(object):
         for sensor in self._sdr.get_sensor_numbers():
             yield {'name': self._sdr.sensors[sensor].name,
                    'type': self._sdr.sensors[sensor].sensor_type}
+
+    def set_channel_access(channel=1, access_update_mode='non_volatile', 
+                           alerting=False, per_msg_auth=False, user_level_auth=False, 
+                           access_mode='always', privilege_update_mode='non_volatile', 
+                           privilege_level='administrator'):
+        '''
+        :param kwargs_conn: bmc_host='127.0.0.1' bmc_user='admin' bmc_pass='example' bmc_port=623
+    
+        :param channel: int in range 1-8
+    
+        access_update_mode='non_volatile'
+        regarding.. alerting, per_msg_auth, user_level_auth and access_mode
+        access_update_modes = { 
+            'dont_change': 0,    don’t set or change Channel Access
+            'non_volatile': 1,   set non-volatile Channel Access
+            'volatile': 2,      set volatile (active) setting of Channel Access
+        }
+    
+        :param alerting: PEF Alerting Enable/Disable
+        True  = enable PEF Alerting
+        False = disable PEF Alerting on this channel (the Alert Immediate command can still be used to generate alerts)
+    
+        
+        :param per_msg_auth: Per-message Authentication
+          True  = enable
+          False = disable Per-message Authentication. [Authentication required to
+                activate any session on this channel, but authentication not used
+                on subsequent packets for the session.]
+    
+        :param user_level_auth: User Level Authentication Enable/Disable.
+    
+            True  = enable User Level Authentication. All User Level commands are
+                to be authenticated per the Authentication Type that was
+                negotiated when the session was activated.
+    
+            False = disable User Level Authentication. Allow User Level commands to
+                be executed without being authenticated.
+                If the option to disable User Level Command authentication is
+                accepted, the BMC will accept packets with Authentication Type
+                set to None if they contain user level commands.
+                For outgoing packets, the BMC returns responses with the same
+                Authentication Type that was used for the request.
+    
+        
+        :param access_mode: Access Mode for IPMI messaging 
+            (PEF Alerting is enabled/disabled separately from IPMI messaging, see 'alerting')
+            disabled = disabled for IPMI messaging
+            pre_boot = pre-boot only channel only available when system is in a 
+                    powered down state or in BIOS prior to start of boot.
+            always = channel always available for communication regardless of system
+                    mode. BIOS typically dedicates the serial connection to the BMC.
+            shared = same as always available, but BIOS typically leaves the serial port
+                    available for software use.
+    
+        :param privilege_update_mode: Channel Privilege Level Limit.
+                    This value sets the maximum privilege level
+                    that can be accepted on the specified channel.
+            dont_change = don’t set or change channel Privilege Level Limit
+            non_volatile = non-volatile Privilege Level Limit according to bits [3:0]
+            volatile = volatile setting of Privilege Level Limit according to bits [3:0]
+    
+    
+        :param privilege_level: Channel Privilege Level Limit
+           * reserved
+           * callback
+           * user
+           * operator
+           * administrator
+           * proprietary
+        '''
+        data = []
+        data.append(channel & 0b00001111)
+        access_update_modes = { 
+            'dont_change': 0,
+            'non_volatile': 1,
+            'volatile': 2,
+            #'reserved': 3
+        }
+        b = 0
+        b |= (access_update_modes[access_update_mode] << 6) & 0b11000000
+        if alerting:
+            b |= 0b00100000
+        if per_msg_auth:
+            b |= 0b00010000
+        if user_level_auth:
+            b |= 0b00001000
+        access_modes = {
+            'disabled': 0,
+            'pre_boot': 1,
+            'always': 2,
+            'shared': 3
+        }
+        b |= access_modes[access_mode] & 0b00000111
+        data.append(b)
+        b = 0
+        privilege_update_modes = { 
+            'dont_change': 0,
+            'non_volatile': 1,
+            'volatile': 2,
+            #'reserved': 3
+        }
+        b |= (privilege_update_modes[privilege_update_mode] << 6) & 0b11000000
+        privilege_levels = {
+            'reserved': 0,
+            'callback': 1,
+            'user': 2,
+            'operator': 3,
+            'administrator': 4,
+            'proprietary': 5,
+            # 'no_access': 0x0F,
+        }
+        b |= privilege_levels[privilege_level] & 0b00000111
+        response = raw_command(netfn=0x06, command=0x40, data=data)
+        if 'error' in response:
+            raise Exception(response['error'])
+        return True
+
+    def get_channel_access(channel=1, read_mode='non_volatile'):
+        '''
+        :param channel: int in range 1-8
+        :param read_mode: one of 
+                {
+                    non_volatile: get non-volatile Channel Access
+                    volatile: get present volatile (active) setting of Channel Access
+                }
+        
+        :return:
+        
+            A Python dict with the following keys/values:
+        
+            - alerting:
+            
+            - per_msg_auth:
+            
+            - user_level_auth:
+            
+            - access_mode:{
+                0: 'disabled',
+                1: 'pre_boot',
+                2: 'always',
+                3: 'shared'
+                }
+            
+            - privilege_level: {
+                1: 'callback',
+                2: 'user',
+                3: 'operator',
+                4: 'administrator',
+                5: 'proprietary',
+                }
+        '''
+        data = []
+        data.append(channel & 0b00001111)
+        b = 0
+        read_modes = { 
+            'non_volatile': 1,
+            'volatile': 2,
+        }
+        b |= (read_modes[read_mode] << 6) & 0b11000000
+        data.append(b)
+        
+        response = raw_command(netfn=0x06, command=0x41, data=data)
+        if 'error' in response:
+            raise Exception(response['error'])
+        
+        data = response['data']
+        if len(data) != 2:
+            raise Exception('expecting 2 data bytes')
+        
+        r = {}
+        r['alerting'] = data[0] & 0b10000000 > 0
+        r['per_msg_auth'] = data[0] & 0b01000000 > 0
+        r['user_level_auth'] = data[0] & 0b00100000 > 0
+        access_modes = {
+            0: 'disabled',
+            1: 'pre_boot',
+            2: 'always',
+            3: 'shared'
+        }
+        r['access_mode'] = access_modes[data[0] & 0b00000011]
+        privilege_levels = {
+            #0: 'reserved',
+            1: 'callback',
+            2: 'user',
+            3: 'operator',
+            4: 'administrator',
+            5: 'proprietary',
+            #0x0F: 'no_access'
+        }
+        r['privilege_level'] = privilege_levels[data[1] & 0b00001111]
+        return r
+
+    def get_channel_info(channel=1):
+        '''
+        
+        :return:
+        
+            session_support:
+                no_session: channel is session-less
+                single: channel is single-session
+                multi: channel is multi-session
+                auto: channel is session-based (return this value if a channel could
+                    alternate between single- and multi-session operation, as can
+                    occur with a serial/modem channel that supports connection
+                    mode auto-detect)
+        '''
+        data = []
+        data.append(channel & 0b00001111)
+        response = raw_command(netfn=0x06, command=0x42, data=data)
+        if 'error' in response:
+            raise Exception(response['error'])
+        
+        data = response['data']
+        if len(data) != 2:
+            raise Exception('expecting 2 data bytes')
+        
+        r = {}
+        r['Actual channel'] = data[1] & 0b00000111
+        r['Channel Medium type'] = data[2] & 0b01111111
+        r['5-bit Channel IPMI Messaging Protocol Type'] = data[3] & 0b00001111
+        session_supports = {
+            0: 'no_session',
+            1: 'single',
+            2: 'multi',
+            3: 'auto'
+        }
+        r['session_support'] = (session_supports[data[4]] << 6) & 0b11000000
+        r['active_session_count'] = data[4] & 0b00111111
+        r['Vendor ID'] = [data[5],data[6],data[7]]
+        r['Auxiliary Channel Info'] = [data[8],data[9]]
+        return r
+
+    def set_user_access(uid, channel=1, callback=True, link_auth=True, ipmi_msg=True, privilege_level='administrator'):
+        '''
+        callback: User Restricted to Callback:
+    
+        (disable): User Privilege Limit is determined by the User Privilege Limit
+        parameter, below, for both callback and non-callback connections.
+        
+        (enable): User Privilege Limit is determined by the User Privilege Limit
+        parameter for callback connections, but is restricted to Callback
+        level for non-callback connections. Thus, a user can only initiate a
+        Callback when they ‘call in’ to the BMC, but once the callback
+        connection has been made, the user could potentially establish a
+        session as an Operator.
+    
+    
+        allow_auth: User Link authentication:
+    
+        enable/disable (used to enable whether this
+        user’s name and password information will be used for link
+        authentication, e.g. PPP CHAP) for the given channel. Link
+        authentication itself is a global setting for the channel and is
+        enabled/disabled via the serial/modem configuration parameters.
+    
+    
+        ipmi_msg(true/false): User IPMI Messaginge:
+    
+        (used to enable/disable whether
+        this user’s name and password information will be used for IPMI
+        Messaging. In this case, “IPMI Messaging” refers to the ability to
+        execute generic IPMI commands that are not associated with a
+        particular payload type. For example, if IPMI Messaging is disabled for
+        a user, but that user is enabled for activatallow_authing the SOL payload type,
+        then IPMI commands associated with SOL and session management,
+        such as Get SOL Configuration Parameters and Close Session are
+        available, but generic IPMI commands such as Get SEL Time are
+        unavailable.)
+        
+        
+        channel: 4 bit number (1-7)
+        
+        privilege_level:
+        User Privilege Limit. (Determines the maximum privilege level that the
+        user is allowed to switch to on the specified channel.)
+    
+            * callback
+            * user
+            * operator
+            * administrator
+            * proprietary
+            * no_access
+        '''   
+        first_byte = 0b10000000
+        if callback:
+            first_byte |= 0b01000000
+        if link_auth:
+            first_byte |= 0b00100000
+        if ipmi_msg:
+            first_byte |= 0b00010000
+        first_byte |= channel & 0b00001111
+        privilege_levels = {
+            'reserved': 0,
+            'callback': 1,
+            'user': 2,
+            'operator': 3,
+            'administrator': 4,
+            'proprietary': 5,
+            'no_access': 0x0F,
+        }
+        data = [first_byte, uid & 0b00111111, privilege_levels[privilege_level] & 0b00001111]
+        response = raw_command(netfn=0x06, command=0x43, data=data)
+        if 'error' in response:
+            raise Exception(response['error'])
+        return True
+
+    def get_user_access(uid, channel=1):
+        '''
+        
+        :return:
+        
+        channel_info:
+            # maximum number of user IDs on this channel
+            max_user_count
+            # count of currently enabled user IDs on this channel (Indicates how many User ID slots are presently in use.)
+            enabled_users
+            # count of user IDs with fixed names on this channel
+            users_with_fixed_names
+        
+        access:
+            callback
+            link_auth
+            ipmi_msg
+            privilege_level: [callback, user, operatorm administrator, proprietary, no_access]
+        
+        '''
+        ## user access available during call-in or callback direct connection
+        data = [channel, uid]
+        response = raw_command(netfn=0x06, command=0x44, data=data)
+        if 'error' in response:
+            raise Exception(response['error'])
+        data = response['data']
+        if len(data) != 4:
+            raise Exception('expecting 4 data bytes')
+        r = {'channel_info': {}, 'access': {}}
+        r['channel_info']['max_user_count'] = data[0]    
+        r['channel_info']['enabled_users'] = data[1] & 0b00111111
+        r['channel_info']['users_with_fixed_names'] = data[2] & 0b00111111
+        r['access']['callback'] = (data[3] & 0b01000000) != 0
+        r['access']['link_auth'] = (data[3] & 0b00100000) != 0
+        r['access']['ipmi_msg'] = (data[3] & 0b00010000) != 0
+        privilege_levels = {
+            #0: 'reserved',
+            1: 'callback',
+            2: 'user',
+            3: 'operator',
+            4: 'administrator',
+            5: 'proprietary',
+            0x0F: 'no_access'
+        }
+        r['access']['privilege_level'] = privilege_level[data[3] & 0b00001111]
+        return r
+
+    def set_user_name(uid, name):
+        '''
+        Set user name
+        
+        :param uid: id number of user
+        :param name:
+        '''
+        data = [uid]
+        if len(name) > 16:
+            raise Exception('name must be less than or = 16 chars')
+        name = name.ljust(16, "\x00")
+        data.extend( [ord(x) for x in name] )
+        response = raw_command(netfn=0x06, command=0x45, data=data)
+        if 'error' in response:
+            raise Exception(response['error'])
+        return True
+
+    def get_user_name(uid):
+        '''
+        Get user name
+        
+        :param uid: id number of user
+        
+        '''
+        response = raw_command(netfn=0x06, command=0x46, data=(uid,))
+        if 'error' in response:
+            raise Exception(response['error'])
+        name = None
+        if 'data' in response:
+            data = response['data']
+            if len(data) == 16:
+                # convert int array to string
+                n = ''.join( chr(data[i]) for i in range(0, len(data)) )
+                # remove padded \x00 chars
+                n = n.rstrip("\x00")
+                if len(n) > 0:
+                    name = n
+        return name
+
+    def set_user_password(uid, mode='set_password', password=None):
+        '''
+        Set user password data
+        
+        :param uid: id number of user.  see: get_names_uid()['name']
+        
+        :param mode: {
+            'disable': disable user connections
+            'enable': enable user connections
+            'set_password': set or ensure password
+            'test_password': test password is correct
+        }
+    
+        :param password: max 16 char string (optional when mode is [disable or enable])
+        '''
+        mode_mask = {
+            'disable': 0,
+            'enable': 1,
+            'set_password': 2,
+            'test_password': 3
+        }
+        data = [uid, mode_mask[mode]]
+        if password:
+            if len(password) > 16:
+                raise Exception('password has limit of 16 chars')
+            password = password.ljust(16, "\x00")
+            data.extend( [ord(x) for x in password] )
+        response = raw_command(netfn=0x06, command=0x47, data=data)
+        if 'error' in response:
+            raise Exception(response['error'])
+        return True
+  


### PR DESCRIPTION
this commit is not tested!
I'm just using it as a way to communicate :)

add extra IPMI calls.  more work is still needed to cleanup doc strings.
also pyghmi/ipmi/private/constants.py should be updated with the error codes returned from the added ipmi calls.

perhaps it would be best if a new file was created /raw.py/
it could focuse on just the raw IPMI  api calls. Where command.py could be used to house helper calls...

helper calls like:
get_sensor_descriptions, get_health, set_power
```
def user_create(uid, name, password, channel=1, callback=False, 
                link_auth=True, ipmi_msg=True, privilege_level='administrator'):
    '''
    Helper function to create users
    
    privilege_level:
    User Privilege Limit. (Determines the maximum privilege level that the
    user is allowed to switch to on the specified channel.)

        * callback
        * user
        * operator
        * administrator
        * proprietary
        * no_access
    '''
    set_user_name(uid, name)
    set_user_access(uid, channel, callback=callback, link_auth=link_auth, ipmi_msg=ipmi_msg, privilege_level=privilege_leve)
    set_user_password(uid, password)
    set_user_password(uid, password, mode='enable')
    return True
```