### PR TITLE
Entity ID lookup with default value

### DIFF
--- a/pyghmi/ipmi/sdr.py
+++ b/pyghmi/ipmi/sdr.py
@@ -317,7 +317,8 @@ class SDREntry(object):
         # this function handles the common aspects of compact and full
         # offsets from spec, minus 6
         self.sensor_number = entry[2]
-        self.entity = ipmiconst.entity_ids[entry[3]]
+        # entity id 144 is unknow on ipmitools
+        self.entity = ipmiconst.entity_ids.get(entry[3], 'unknown')
         self.sensor_type_number = entry[7]
         try:
             self.sensor_type = ipmiconst.sensor_type_codes[entry[7]]


### PR DESCRIPTION
While doing a common decode of SDR data, the identification of the entity is done by a dict lookup which may not have the entity_id as a key for identification, thus, adding an 'unknown' as default result should prevent unnecessary crashes.